### PR TITLE
Updated "winslop" -> "winslopr" **only** in docs and github pages URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Then Microsoft said "slop vs sophistication" out loud and it stopped being one.
 
 ---
 
-### 📋 [What annoys you most about Windows 11?](https://builtbybel.github.io/Winslop/annoyances/)
+### 📋 [What annoys you most about Windows 11?](https://builtbybel.github.io/Winslopr/annoyances/)
 
 59 community-sourced annoyances. Filterable. With fixes.  
 See what Winslopr handles and what needs extra tools.
@@ -34,7 +34,7 @@ Windows
     ├── suggestions
     └── background junk
          ↓
-      removed by winslop
+      removed by winslopr
          ↓
        thanks
         Satya
@@ -48,13 +48,13 @@ Nothing fancy. Just tools.
 <sub>Click to expand. No assistant required.</sub>
 
 <details>
-<summary><strong>Is Winslop anti-Windows?</strong></summary>
+<summary><strong>Is Winslopr anti-Windows?</strong></summary>
 
 No.  
 Windows itself is fine.  
 The unnecessary stuff layered on top of it isn’t.
 
-Winslop targets **slop**, not Windows.
+Winslopr targets **slop**, not Windows.
 </details>
 
 <details>
@@ -71,7 +71,7 @@ There's a small, lightweight entry guide to get you going:
 
 Also no.
 
-Winslop doesn’t care whether something is AI, scripted, cloud-based or hand-written.  
+Winslopr doesn’t care whether something is AI, scripted, cloud-based or hand-written.  
 If it’s forced, opaque, or unnecessary, its slop.
 
 If it’s optional, transparent and useful, it’s fine.
@@ -79,7 +79,7 @@ If it’s optional, transparent and useful, it’s fine.
 
 
 <details>
-<summary><strong>Does Winslop use AI?</strong></summary>
+<summary><strong>Does Winslopr use AI?</strong></summary>
 
 No.
 
@@ -92,16 +92,16 @@ Everything is deterministic and based on explicit user choices.
 
 No.
 
-Winslop does not upload logs, telemetry, system data or usage statistics.  
+Winslopr does not upload logs, telemetry, system data or usage statistics.  
 All actions happen locally on your machine.
 </details>
 
 <details>
-<summary><strong>Can Winslop break my system?</strong></summary>
+<summary><strong>Can Winslopr break my system?</strong></summary>
 
 Any system tool can if misused.
 
-That’s why Winslop:
+That’s why Winslopr:
 - shows exactly what it will change  
 - never runs anything automatically  
 - allows changes to be reviewed and reverted  
@@ -115,7 +115,7 @@ You stay in control.
 
 You can.
 
-Winslop exists for people who prefer:
+Winslopr exists for people who prefer:
 - fewer layers  
 - less abstraction  
 - no opinions  
@@ -129,7 +129,7 @@ Just tools.
 
 Yes.
 
-Winslop is a very small, focused fork of CrapFixer.  
+Winslopr is a very small, focused fork of CrapFixer.  
 The goal was to remove complexity, reduce scope and make things easier to maintain.
 
 Smaller codebase.  
@@ -145,7 +145,7 @@ Because Microsoft said *“slop vs sophistication”* out loud.
 And because Windows isn't bad.  
 The slop is.
 
-Winslop is **anti-slop by design**.
+Winslopr is **anti-slop by design**.
 
 That’s why the UI is intentionally small, plain and functional.
 No glossy visuals.  
@@ -158,7 +158,7 @@ Slop comes in many forms:
 - **UX / Design slop** > bloated, unclear interfaces
 - **Corporate slop** > buzzwords, filler and dark patterns
 
-Winslop does the opposite:
+Winslopr does the opposite:
 It removes more than it adds.
 </details>
 
@@ -187,10 +187,8 @@ So no, the word didn’t exist. Now it does
 </details>
 
 <details>
-<summary><strong>What is Winslop written in?</strong></summary>
+<summary><strong>What is Winslopr written in?</strong></summary>
 
 C# with WinUI 3. Started as a fork of CrapFixer, rebuilt from scratch to be smaller and more focused.
 
 </details>
-
-

--- a/Winslop.Legacy/Winslop/Helpers/LogActionsController.cs
+++ b/Winslop.Legacy/Winslop/Helpers/LogActionsController.cs
@@ -50,7 +50,7 @@ public class LogActionsController
         switch (selected)
         {
             case "Inspect log online (recommended)":
-                _logActions.AnalyzeOnline("https://builtbybel.github.io/Winslop/log-inspector/index.html");
+                _logActions.AnalyzeOnline("https://builtbybel.github.io/Winslopr/log-inspector/index.html");
                 break;
 
             case "Copy log to clipboard":

--- a/Winslop.Legacy/Winslop/MainForm.cs
+++ b/Winslop.Legacy/Winslop/MainForm.cs
@@ -47,7 +47,7 @@ namespace Winslop
             EventHandler showAbout = (_, __) => new AboutForm().ShowDialog();
             lblRightHeader.Click += showAbout;
             toolStripMenuAbout.Click += showAbout;
-            toolStripMenuUpdate.Click += (s, _) => Process.Start($"https://builtbybel.github.io/Winslop/update.html?version={Program.GetAppVersion()}");
+            toolStripMenuUpdate.Click += (s, _) => Process.Start($"https://builtbybel.github.io/Winslopr/update.html?version={Program.GetAppVersion()}");
 
             // Initialize log actions controller
             _logActionsController = new LogActionsController(comboLogActions, _logActions);

--- a/Winslopr/Strings/LOCALIZATION.md
+++ b/Winslopr/Strings/LOCALIZATION.md
@@ -1,6 +1,6 @@
 # Localization Guide
 
-Winslop uses the standard WinUI 3 resource system (`.resw` files) for translations.
+Winslopr uses the standard WinUI 3 resource system (`.resw` files) for translations.
 This guide explains how translations work and how you can contribute.
 
 ---
@@ -42,7 +42,7 @@ what part of the app you're translating:
 2. **Translate** every `<value>...</value>` — do NOT change the `name` attributes
 3. **Keep placeholders** like `{0}`, `{1}` — they get replaced with numbers/text at runtime
 4. **Keep special characters** like `&lt;` (this is `<` in XML) and `&#x2764;` (heart emoji)
-5. **Don't translate** brand names: Winslop, Copilot, Edge, Ko-fi, PayPal, CFEnhancer
+5. **Don't translate** brand names: Winslopr, Copilot, Edge, Ko-fi, PayPal, CFEnhancer
 
 **Example:**
 
@@ -66,7 +66,7 @@ That's it! The developer will handle the project configuration, menu entry,
 and compilation. You just provide the translated `.resw` file.
 
 **Tips for a good translation:**
-- Keep the same tone — Winslop is informal and direct
+- Keep the same tone — Winslopr is informal and direct
 - The section comments in the file tell you which page each group belongs to
 - If a value looks technical or unclear, check the English version in context
   by looking at the section header (e.g. "ToolsPage", "Donation dialog")

--- a/docs/Help.md
+++ b/docs/Help.md
@@ -6,13 +6,13 @@ Quick links:
 - [Feature Reference](features.md)
 - [Plugins Reference](plugins.md)
 - [Extensions Reference](extensions.md)
-- [Windows 11 Annoyances](https://builtbybel.github.io/Winslop/annoyances/) — 59 community-sourced annoyances with fixes
+- [Windows 11 Annoyances](https://builtbybel.github.io/Winslopr/annoyances/) — 59 community-sourced annoyances with fixes
 
 ---
 
 ## Getting started
 
-1. Run **Winslop.exe**
+1. Run **Winslopr.exe**
 2. Click **Inspect system** — scans your system and highlights issues
 3. Review the results in the feature tree (checkboxes)
 4. Click **Apply selected changes** to fix checked items
@@ -23,7 +23,7 @@ That's it. No account, no setup wizard, no cloud.
 
 ## Navigation
 
-Winslop uses a left sidebar with five sections:
+Winslopr uses a left sidebar with five sections:
 
 | Icon | Tab | What it does |
 |------|-----|-------------|
@@ -99,7 +99,7 @@ _App list adapted from [WinUtil by Chris Titus Tech](https://github.com/ChrisTit
 
 ## Tools tab
 
-PowerShell-based extensions that ship with Winslop. Select a tool on the left, configure options on the right, click **Run**.
+PowerShell-based extensions that ship with Winslopr. Select a tool on the left, configure options on the right, click **Run**.
 
 Included tools:
 - **Post-setup Cleanup** — disk cleanup, clear update cache, remove Windows.old
@@ -143,7 +143,7 @@ The bottom panel shows a live log of all actions. Use the **[···] menu → Lo
 
 ## Safety
 
-- Winslop shows exactly what it will change before applying
+- Winslopr shows exactly what it will change before applying
 - Nothing runs automatically — you choose what to fix
 - Changes can be reverted via right-click → Restore
 - No data is uploaded — everything stays local

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,7 +1,7 @@
 # Plugins
 
-Winslop plugins are **PowerShell scripts (`.ps1`) with an INI-style header**.
-Winslop reads the header to decide what to run (Check / Do / Undo) and may validate results via [Expect].
+Winslopr plugins are **PowerShell scripts (`.ps1`) with an INI-style header**.
+Winslopr reads the header to decide what to run (Check / Do / Undo) and may validate results via [Expect].
 
 Plugins can:
 - modify registry / services / files via commands
@@ -47,7 +47,7 @@ The demo pack uses a simple rule-driven model:
 
 ## Naming and Help anchors
 
-Winslop’s help system can link directly into GitHub docs by using the plugin title as an anchor.
+Winslopr’s help system can link directly into GitHub docs by using the plugin title as an anchor.
 That means:
 
 - The plugin **display title** should match the markdown heading in `features.md` (plugins section)
@@ -64,7 +64,7 @@ Example:
 
 ## [Commands]
 
-`[Commands]` defines the metadata and the actions Winslop can run.
+`[Commands]` defines the metadata and the actions Winslopr can run.
 
 Supported keys:
 - `Info` — shown in the UI as plugin description
@@ -113,5 +113,3 @@ Undo=reg add "HKCU\Software\Microsoft\Windows\CurrentVersion\Search" /v BingSear
 [Expect]
 BingSearchEnabled=0x0
 ```
-
-


### PR DESCRIPTION
## Included
- The links to the github pages website for Winslopr were broken, e.g. README.md linked to https://builtbybel.github.io/Winslop/annoyances (broken) instead of https://builtbybel.github.io/Winslopr/annoyances (fixed)  
- Also updated many non-code spots where the new name should be used, but he old one was still there.
## Not included
- URLs pointing to the main repo
  - Github still redirects https://github.com/builtbybel/Winslop -> https://github.com/builtbybel/Winslopr, so I didn't change any instances of that.
- C# code (aside from the above mentioned github pages URLs